### PR TITLE
Pin profile and logout buttons to the right

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -4,6 +4,7 @@
   text-align: center;
   min-height: 100vh;
   background-color: #f8fafc;
+  padding-top: 4rem; /* Add top padding to account for fixed navbar */
 }
 
 .loading {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -7,6 +7,10 @@
   padding-top: 4rem; /* Add top padding to account for fixed navbar */
 }
 
+.pt-16 {
+  padding-top: 4rem;
+}
+
 .loading {
   display: flex;
   justify-content: center;

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -12,7 +12,7 @@ const Navbar = () => {
           <h1 className="text-xl font-bold text-gray-900">Timeline App</h1>
         </div>
         
-        <div className="navbar-right">
+        <div className="navbar-right-absolute">
           <div className="flex items-center gap-2 text-gray-700">
             <User size={20} />
             <span className="font-medium">{user?.username}</span>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -8,9 +8,6 @@ const Navbar = () => {
   return (
     <nav className="navbar-fixed">
       <div className="navbar-content">
-        <div className="navbar-left">
-          <h1 className="text-xl font-bold text-gray-900">Timeline App</h1>
-        </div>
         
         <div className="navbar-right-absolute">
           <div className="flex items-center gap-2 text-gray-700">

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -6,7 +6,7 @@ const Navbar = () => {
   const { user, logout } = useAuth();
 
   return (
-    <nav className="bg-white shadow-sm border-b border-gray-200">
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm border-b border-gray-200">
       <div className="container">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -6,27 +6,25 @@ const Navbar = () => {
   const { user, logout } = useAuth();
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-white shadow-sm border-b border-gray-200">
-      <div className="container">
-        <div className="flex items-center justify-between h-16">
-          <div className="flex items-center">
-            <h1 className="text-xl font-bold text-gray-900">Timeline App</h1>
+    <nav className="navbar-fixed">
+      <div className="navbar-content">
+        <div className="navbar-left">
+          <h1 className="text-xl font-bold text-gray-900">Timeline App</h1>
+        </div>
+        
+        <div className="navbar-right">
+          <div className="flex items-center gap-2 text-gray-700">
+            <User size={20} />
+            <span className="font-medium">{user?.username}</span>
           </div>
           
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2 text-gray-700">
-              <User size={20} />
-              <span className="font-medium">{user?.username}</span>
-            </div>
-            
-            <button
-              onClick={logout}
-              className="btn btn-secondary"
-            >
-              <LogOut size={16} />
-              Logout
-            </button>
-          </div>
+          <button
+            onClick={logout}
+            className="btn btn-secondary"
+          >
+            <LogOut size={16} />
+            Logout
+          </button>
         </div>
       </div>
     </nav>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -73,6 +73,16 @@ code {
   gap: 1rem;
 }
 
+.navbar-right-absolute {
+  position: absolute;
+  top: 0.5rem;
+  right: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  z-index: 51;
+}
+
 /* Utility Classes */
 .container {
   max-width: 1200px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -19,6 +19,27 @@ code {
     monospace;
 }
 
+/* Fixed positioning classes */
+.fixed {
+  position: fixed;
+}
+
+.top-0 {
+  top: 0;
+}
+
+.left-0 {
+  left: 0;
+}
+
+.right-0 {
+  right: 0;
+}
+
+.z-50 {
+  z-index: 50;
+}
+
 /* Utility Classes */
 .container {
   max-width: 1200px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -40,6 +40,39 @@ code {
   z-index: 50;
 }
 
+/* Navbar specific styles */
+.navbar-fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  background: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.navbar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.navbar-left {
+  display: flex;
+  align-items: center;
+}
+
+.navbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
 /* Utility Classes */
 .container {
   max-width: 1200px;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Pin logout and profile buttons to the right side of the screen by making the Navbar fixed and adjusting content spacing.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The Navbar was updated to use `fixed` positioning, `top-0`, `left-0`, `right-0`, and `z-50` to ensure it stays at the top of the viewport. To prevent content from being obscured by the fixed Navbar, `padding-top: 4rem` was added to the main App container.

---
<a href="https://cursor.com/background-agent?bcId=bc-36d43239-cbc2-4a09-b8ee-8c1b0fbd1e3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36d43239-cbc2-4a09-b8ee-8c1b0fbd1e3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>